### PR TITLE
Online input plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
+.idea           # pycharm
 /.project
-.idea       # pycharm
-*~          # gedit
+*~              # gedit
 
 # Pyton cache
 *.pyc


### PR DESCRIPTION
This includes a new input plugin with a few new features:
  * Read data while acquisition is in progress.
  * Read substantially faster by not querying mongodb separately for every event
  * Use the `--input` argument of paxer to specify the database used

The old plugin is also modified to avoid code duplication. I have no idea if it works yet, for that we'd have to test it.

